### PR TITLE
feat: support IRC replies to Discord threads

### DIFF
--- a/src/bridge/irc.ts
+++ b/src/bridge/irc.ts
@@ -9,6 +9,10 @@ import {
   PrivMsgChannelEvent,
   QuitEvent,
 } from "./utils.ts";
+import {
+  resolveBridgedDiscordThreads,
+  resolveDiscordTargetFromIrc,
+} from "./resolver.ts";
 
 export function registerIrcHandlers(runtime: BridgeRuntime) {
   const { bot, channelId, client, config, members } = runtime;
@@ -34,22 +38,46 @@ export function registerIrcHandlers(runtime: BridgeRuntime) {
             ).join(" @")
           }`,
         );
+        return;
+      } else if (payload.params.text === "$threads") {
+        const threads = await resolveBridgedDiscordThreads(runtime);
+        const threadNames = threads.map((thread) => thread.name).filter(
+          Boolean,
+        );
+        client.privmsg(
+          config.IRC_CHANNEL,
+          threadNames.length > 0
+            ? `Discord threads: ${threadNames.join(", ")}`
+            : "Discord threads: none",
+        );
+        return;
       } else if (payload.params.text === "$ping") {
         client.privmsg(config.IRC_CHANNEL, "Pong!");
+        return;
       }
     }
 
-    await bot.helpers.sendMessage(channelId, {
+    const target = await resolveDiscordTargetFromIrc(
+      runtime,
+      payload.params.text,
+    );
+
+    await bot.helpers.sendMessage(target.channelId, {
       content: `<${payload.source?.name || "User"}> ${
-        ircMsgToDiscord(runtime, payload.params.text)
+        ircMsgToDiscord(runtime, target.text)
       }`,
     });
   });
 
   client.on("ctcp_action", async (payload: CtcpActionEvent) => {
-    await bot.helpers.sendMessage(channelId, {
+    const target = await resolveDiscordTargetFromIrc(
+      runtime,
+      payload.params.text,
+    );
+
+    await bot.helpers.sendMessage(target.channelId, {
       content: `*** * ${payload.source?.name || "User"} ${
-        ircMsgToDiscord(runtime, payload.params.text)
+        ircMsgToDiscord(runtime, target.text)
       }`,
     });
   });

--- a/src/bridge/resolver.ts
+++ b/src/bridge/resolver.ts
@@ -57,3 +57,57 @@ export async function resolveQuotedMessageContent(
   );
   return message.content;
 }
+
+type DiscordTarget = {
+  channelId: bigint;
+  text: string;
+};
+
+const THREAD_PREFIX_RE = /^\[in ([^\]]+)\]\s*/;
+
+function normalizeThreadName(name: string) {
+  return name.trim().toLowerCase();
+}
+
+export async function resolveBridgedDiscordThreads(runtime: BridgeRuntime) {
+  const activeThreads = await runtime.bot.helpers.getActiveThreads(
+    runtime.guildId,
+  );
+  return [...activeThreads.threads.values()].filter((channel) =>
+    channel.parentId === runtime.channelId && channel.name
+  );
+}
+
+export async function resolveDiscordTargetFromIrc(
+  runtime: BridgeRuntime,
+  text: string,
+): Promise<DiscordTarget> {
+  const match = text.match(THREAD_PREFIX_RE);
+  if (!match) {
+    return { channelId: runtime.channelId, text };
+  }
+
+  const requestedName = normalizeThreadName(match[1]);
+  const trimmedText = text.slice(match[0].length);
+  const bridgedThreads = await resolveBridgedDiscordThreads(runtime);
+
+  const exactMatch = bridgedThreads.find((channel) =>
+    normalizeThreadName(channel.name || "") === requestedName
+  );
+  if (exactMatch) {
+    return { channelId: exactMatch.id, text: trimmedText };
+  }
+
+  const prefix = requestedName.endsWith("…")
+    ? requestedName.slice(0, -1)
+    : requestedName;
+  const prefixMatches = bridgedThreads.filter((channel) =>
+    normalizeThreadName(channel.name || "").startsWith(prefix)
+  );
+
+  if (prefixMatches.length === 1) {
+    return { channelId: prefixMatches[0].id, text: trimmedText };
+  }
+
+  return { channelId: runtime.channelId, text };
+}


### PR DESCRIPTION
Problem

  IRC users could see when Discord messages came from a thread because the bridge emitted [in ...] labels, but replies sent from IRC were always posted back to the parent Discord channel. The initial attempt to route these messages also failed because it used getChannels(), and Discordeno excludes thread channels from that helper.

Solution:
The bridge now parses a leading IRC thread prefix such as [in test] or [in c&c generals: z…], resolves it against the active Discord threads under the configured bridged channel, strips the prefix, and posts the remaining message into the matching thread. I also added an IRC $threads command to list active bridged Discord threads and made IRC-side commands stop echoing into Discord as normal chat.

Testing
No unit tests or integration tests as per OG author wishes
